### PR TITLE
Add ContainerNodes and source_created_at/source_deleted_at

### DIFF
--- a/app/models/container_group.rb
+++ b/app/models/container_group.rb
@@ -2,4 +2,5 @@ class ContainerGroup < ApplicationRecord
   belongs_to :tenant
   belongs_to :source
   belongs_to :container_project
+  belongs_to :container_node
 end

--- a/app/models/container_node.rb
+++ b/app/models/container_node.rb
@@ -1,0 +1,5 @@
+class ContainerNode < ApplicationRecord
+  belongs_to :tenant
+  belongs_to :source
+  has_many   :container_groups, :dependent => :nullify
+end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -15,6 +15,7 @@ class Source < ApplicationRecord
   has_many :container_groups,    :dependent => :destroy
   has_many :container_templates, :dependent => :destroy
   has_many :container_projects,  :dependent => :destroy
+  has_many :container_nodes,     :dependent => :destroy
 
   # Service Catalog Inventory Objects
   has_many :service_offerings,       :dependent => :destroy

--- a/db/migrate/20181011164429_add_container_nodes.rb
+++ b/db/migrate/20181011164429_add_container_nodes.rb
@@ -1,0 +1,18 @@
+class AddContainerNodes < ActiveRecord::Migration[5.1]
+  def change
+    create_table "container_nodes", :id => :bigserial do |t|
+      t.references "source", :type => :bigint, :index => true
+      t.string     "source_ref"
+      t.string     "resource_version"
+      t.string     "name"
+      t.integer    "cpus"
+      t.bigint     "memory"
+      t.references "tenant"
+      t.timestamps
+      t.datetime   "deleted_at", :index => true
+      t.index      %i(source_id source_ref), :unique => true
+    end
+
+    add_reference "container_groups", "container_node", :index => true
+  end
+end

--- a/db/migrate/20181011172858_add_source_created_and_deleted_at_timestamps.rb
+++ b/db/migrate/20181011172858_add_source_created_and_deleted_at_timestamps.rb
@@ -1,0 +1,19 @@
+class AddSourceCreatedAndDeletedAtTimestamps < ActiveRecord::Migration[5.1]
+  def change
+    add_column :container_groups,        :source_created_at, :datetime
+    add_column :container_nodes,         :source_created_at, :datetime
+    add_column :container_projects,      :source_created_at, :datetime
+    add_column :container_templates,     :source_created_at, :datetime
+    add_column :service_instances,       :source_created_at, :datetime
+    add_column :service_offerings,       :source_created_at, :datetime
+    add_column :service_parameters_sets, :source_created_at, :datetime
+
+    rename_column :container_groups,        :deleted_at, :source_deleted_at
+    rename_column :container_nodes,         :deleted_at, :source_deleted_at
+    rename_column :container_projects,      :deleted_at, :source_deleted_at
+    rename_column :container_templates,     :deleted_at, :source_deleted_at
+    rename_column :service_instances,       :deleted_at, :source_deleted_at
+    rename_column :service_offerings,       :deleted_at, :source_deleted_at
+    rename_column :service_parameters_sets, :deleted_at, :source_deleted_at
+  end
+end

--- a/lib/topological_inventory/schema/default.rb
+++ b/lib/topological_inventory/schema/default.rb
@@ -8,16 +8,14 @@ module TopologicalInventory
           builder.add_properties(
             :manager_ref    => [:source_ref],
             :secondary_refs => {:by_name => [:name]},
-            :saver_strategy => :concurrent_safe_batch,
           )
           builder.add_default_values(:source_id => ->(persister) { persister.manager.id })
         end
 
-        %i(container_groups container_templates service_offerings service_instances service_parameters_sets).each do |model|
+        %i(container_groups container_nodes container_templates service_offerings service_instances service_parameters_sets).each do |model|
           add_collection(model) do |builder|
             builder.add_properties(
               :manager_ref => [:source_ref],
-              :saver_strategy => :concurrent_safe_batch,
             )
             builder.add_default_values(:source_id => ->(persister) { persister.manager.id })
           end


### PR DESCRIPTION
This adds the ContainerNodes model with a reference to ContainerGroups, and also adds source_created_at and source_deleted_at attributes to all container/service models.

There was already a deleted_at which is what we had in MIQ but since it is coming from the source data I thought it would be better to keep it consistent with source_created_at (MIQ calls this ems_created_on).