### PR TITLE
Create the default endpoint with a tenant

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -7,7 +7,7 @@ class Source < ApplicationRecord
 
   def default_endpoint
     default = endpoints.detect(&:default)
-    default || endpoints.build(:default => true)
+    default || endpoints.build(:default => true, :tenant => tenant)
   end
 
 


### PR DESCRIPTION
When creating the default endpoint set the same tenant as its source.