### PR TITLE
Add missing properties to ContainerTemplate

### DIFF
--- a/app/models/container_template.rb
+++ b/app/models/container_template.rb
@@ -1,4 +1,5 @@
 class ContainerTemplate < ApplicationRecord
   belongs_to :tenant
   belongs_to :source
+  belongs_to :container_project
 end

--- a/db/migrate/20181015150921_add_missing_name_to_container_template.rb
+++ b/db/migrate/20181015150921_add_missing_name_to_container_template.rb
@@ -1,0 +1,5 @@
+class AddMissingNameToContainerTemplate < ActiveRecord::Migration[5.1]
+  def change
+    add_column :container_templates, :name, :string
+  end
+end


### PR DESCRIPTION
The ContainerTemplate model was missing a belongs_to container_project
and the table was missing the name column