### PR TITLE
Setting default find strategy to :local_db_find_missing_references

### DIFF
--- a/lib/topological_inventory/schema/default.rb
+++ b/lib/topological_inventory/schema/default.rb
@@ -30,6 +30,7 @@ module TopologicalInventory
       def add_default_properties(builder)
         builder.add_properties(
           :manager_ref        => [:source_ref],
+          :strategy           => :local_db_find_missing_references,
           :saver_strategy     => :concurrent_safe_batch,
           :retention_strategy => :archive
         )


### PR DESCRIPTION
Currently `:strategy` is not set and lazy_links are not found.

cc @agrare @Ladas 