### PR TITLE
Add a SourceType model for dynamic provider types

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,5 +1,6 @@
 class Source < ApplicationRecord
   has_many :endpoints, :autosave => true
+  belongs_to :source_type
   belongs_to :tenant
 
   delegate :scheme, :scheme=, :host, :host=, :port, :port=, :path, :path=,

--- a/app/models/source_type.rb
+++ b/app/models/source_type.rb
@@ -1,0 +1,3 @@
+class SourceType < ApplicationRecord
+  has_many :sources
+end

--- a/db/migrate/20181024163850_add_source_type.rb
+++ b/db/migrate/20181024163850_add_source_type.rb
@@ -8,6 +8,6 @@ class AddSourceType < ActiveRecord::Migration[5.1]
       t.index :name, :unique => true
     end
 
-    add_reference :sources, :source_type, :index => true
+    add_reference :sources, :source_type,  :index => true, :foreign_key => {:on_delete => :cascade}
   end
 end

--- a/db/migrate/20181024163850_add_source_type.rb
+++ b/db/migrate/20181024163850_add_source_type.rb
@@ -1,0 +1,13 @@
+class AddSourceType < ActiveRecord::Migration[5.1]
+  def change
+    create_table :source_types, :id => :bigserial do |t|
+      t.string :name
+      t.string :product_name
+      t.string :vendor
+      t.timestamps
+      t.index :name, :unique => true
+    end
+
+    add_reference :sources, :source_type, :index => true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -230,12 +230,23 @@ ActiveRecord::Schema.define(version: 20181102145252) do
     t.index ["source_id"], name: "index_source_regions_on_source_id"
   end
 
+  create_table "source_types", force: :cascade do |t|
+    t.string "name"
+    t.string "product_name"
+    t.string "vendor"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["name"], name: "index_source_types_on_name", unique: true
+  end
+
   create_table "sources", force: :cascade do |t|
     t.string "name"
     t.string "uid"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.bigint "tenant_id", null: false
+    t.bigint "source_type_id"
+    t.index ["source_type_id"], name: "index_sources_on_source_type_id"
   end
 
   create_table "subscriptions", force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -336,6 +336,7 @@ ActiveRecord::Schema.define(version: 20181102145252) do
   add_foreign_key "service_plans", "subscriptions", on_delete: :cascade
   add_foreign_key "service_plans", "tenants", on_delete: :cascade
   add_foreign_key "source_regions", "sources", on_delete: :cascade
+  add_foreign_key "sources", "source_types", on_delete: :cascade
   add_foreign_key "sources", "tenants", on_delete: :cascade
   add_foreign_key "subscriptions", "sources", on_delete: :cascade
 end

--- a/spec/persister/worker_spec.rb
+++ b/spec/persister/worker_spec.rb
@@ -2,9 +2,17 @@ require "topological_inventory/persister/worker"
 
 describe TopologicalInventory::Persister::Worker do
   let(:tenant) { Tenant.find_or_create_by!(:name => "default") }
+  let(:source_type) { SourceType.find_or_create_by(:name => "openshift") }
   let(:client) { double(:client) }
-  let!(:source) { Source.find_or_create_by!(:name => "OCP", :uid => "9a874712-9a55-49ab-a46a-c823acc35503", :tenant => tenant) }
   let(:test_inventory_dir) { Pathname.new(__dir__).join("test_inventory") }
+  let!(:source) do
+    Source.find_or_create_by!(
+      :tenant      => tenant,
+      :source_type => source_type,
+      :name        => "OCP",
+      :uid         => "9a874712-9a55-49ab-a46a-c823acc35503",
+    )
+  end
 
   context "#run" do
     let(:messages) { [ManageIQ::Messaging::ReceivedMessage.new(nil, nil, inventory, nil)] }

--- a/spec/tagging/tagging_spec.rb
+++ b/spec/tagging/tagging_spec.rb
@@ -1,6 +1,6 @@
 describe "ActsAsTaggableOn" do
   let(:tenant) { Tenant.find_or_create_by!(:name => "default") }
-  let(:source) { Source.find_or_create_by!(:name => "OCP", :uid => "9a874712-9a55-49ab-a46a-c823acc35503", :tenant => tenant) }
+  let(:source) { Source.find_or_create_by!(:name => "OCP", :uid => "9a874712-9a55-49ab-a46a-c823acc35503", :tenant => tenant, :source_type => SourceType.find_or_create_by!(:name => "openshift")) }
 
   context "common tagging operations" do
     it "is taggable" do


### PR DESCRIPTION
Rather than have a string column for the source type and a pre-defined list of known types, add a table so that source types can be added dynamically along with the json schema for the create/update forms.  Then we can seed the builtin source types like openshift/aws/etc...