### PR TITLE
Support parallel persisters with subscribe_message

### DIFF
--- a/lib/topological_inventory/persister/worker.rb
+++ b/lib/topological_inventory/persister/worker.rb
@@ -23,8 +23,8 @@ module TopologicalInventory
         logger.info("Topological Inventory Persister started...")
 
         # Wait for messages to be processed
-        client.subscribe_topic(queue_opts) do |_, _, payload|
-          process_payload(payload)
+        client.subscribe_messages(queue_opts) do |messages|
+          messages.each { |msg| process_payload(msg.payload) }
         end
       ensure
         client&.close

--- a/spec/persister/worker_spec.rb
+++ b/spec/persister/worker_spec.rb
@@ -7,10 +7,12 @@ describe TopologicalInventory::Persister::Worker do
   let(:test_inventory_dir) { Pathname.new(__dir__).join("test_inventory") }
 
   context "#run" do
+    let(:messages) { [ManageIQ::Messaging::ReceivedMessage.new(nil, nil, inventory, nil)] }
+
     before do
       allow(ManageIQ::Messaging::Client).to receive(:open).and_return(client)
       allow(client).to receive(:close)
-      allow(client).to receive(:subscribe_topic).and_yield(nil, nil, inventory)
+      allow(client).to receive(:subscribe_messages).and_yield(messages)
 
       described_class.new.run
       source.reload


### PR DESCRIPTION
Use subscribe_messages so that inventory is only delivered to a single
persister worker.

Originally the kafka backend for manageiq-messaging had only
publish/subscribe_topic but now it supports queue type methods.

Merge together with: https://github.com/ManageIQ/topological_inventory-ingress_api/pull/4