### PR TITLE
Fix ArHelper require in bin/console

### DIFF
--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,8 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "ar_helper"
+require "topological_inventory/persister/ar_helper"
+TopologicalInventory::Persister::ArHelper.load_environment!
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.


### PR DESCRIPTION
Forgot to update the require on bin/console when ar_helper was moved
from lib to lib/topological_inventory/persister in https://github.com/ManageIQ/topological_inventory-core/pull/26