### PR TITLE
TopologicalInventory::Api was failing to load due to missing gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,8 +5,6 @@ source 'https://rubygems.org'
 # development dependencies will be added by default to the :development group.
 gemspec
 
-gem 'acts-as-taggable-on', '~> 6.0'
-
 # Declare any dependencies that are still in development here instead of in
 # your gemspec. These might include edge Rails or gems from your path or
 # Git. Remember to move these dependencies to your gemspec before releasing
@@ -14,10 +12,6 @@ gem 'acts-as-taggable-on', '~> 6.0'
 
 gem "inventory_refresh", :git => "https://github.com/ManageIQ/inventory_refresh", :branch => "master"
 gem "manageiq-password", :git => "https://github.com/ManageIQ/manageiq-password", :branch => "master"
-
-group :development, :test do
-  gem "rspec-rails"
-end
 
 #
 # Custom Gemfile modifications

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -16,7 +16,10 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_dependency "rails", ">= 5.0.0.racecar1", "< 5.2"
-  s.add_dependency "pg", "> 0"
-  s.add_dependency "manageiq-messaging", "~> 0.1.0"
+  s.add_runtime_dependency "acts-as-taggable-on", '~> 6.0'
+  s.add_runtime_dependency "manageiq-messaging", "~> 0.1.0"
+  s.add_runtime_dependency "pg", "> 0"
+  s.add_runtime_dependency "rails", ">= 5.0.0.racecar1", "< 5.2"
+
+  s.add_development_dependency "rspec-rails", "~>3.8"
 end


### PR DESCRIPTION
```
LoadError: cannot load such file -- acts-as-taggable-on
/home/bdunne/.gem/ruby/2.4.3/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `require'
/home/bdunne/.gem/ruby/2.4.3/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `block in require'
/home/bdunne/.gem/ruby/2.4.3/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:256:in `block in load_dependency'
/home/bdunne/.gem/ruby/2.4.3/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:662:in `new_constants_in'
/home/bdunne/.gem/ruby/2.4.3/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:256:in `load_dependency'
/home/bdunne/.gem/ruby/2.4.3/gems/activesupport-5.1.6/lib/active_support/dependencies.rb:292:in `require'
/home/bdunne/.gem/ruby/2.4.3/bundler/gems/topological_inventory-core-5467994f6246/app/models/application_record.rb:2:in `<class:ApplicationRecord>'
/home/bdunne/.gem/ruby/2.4.3/bundler/gems/topological_inventory-core-5467994f6246/app/models/application_record.rb:1:in `<top (required)>'
```