### PR TITLE
Add VMs and OrchestrationStacks for AWS refresh

### DIFF
--- a/app/models/orchestration_stack.rb
+++ b/app/models/orchestration_stack.rb
@@ -1,11 +1,10 @@
 require "archived_concern"
 
-class Vm < ApplicationRecord
+class OrchestrationStack < ApplicationRecord
   include ArchivedConcern
 
   belongs_to :tenant
   belongs_to :source
-  belongs_to :orchestration_stack
 
   acts_as_taggable
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -29,5 +29,6 @@ class Source < ApplicationRecord
   has_many :subscriptions
 
   # Infra/Cloud
+  has_many :orchestration_stacks
   has_many :vms
 end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -27,4 +27,7 @@ class Source < ApplicationRecord
   has_many :service_plans
   has_many :source_regions
   has_many :subscriptions
+
+  # Infra/Cloud
+  has_many :vms
 end

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -5,6 +5,7 @@ class Tenant < ActiveRecord::Base
   has_many :container_projects
   has_many :container_templates
   has_many :endpoints
+  has_many :orchestration_stacks
   has_many :service_instances
   has_many :service_offerings
   has_many :service_plans

--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -12,6 +12,7 @@ class Tenant < ActiveRecord::Base
   has_many :sources
   has_many :subscriptions
   has_many :tasks
+  has_many :vms
 
   acts_as_taggable
 end

--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -1,0 +1,10 @@
+require "archived_concern"
+
+class Vm < ApplicationRecord
+  include ArchivedConcern
+
+  belongs_to :tenant
+  belongs_to :source
+
+  acts_as_taggable
+end

--- a/db/migrate/20181113182615_add_vms_table.rb
+++ b/db/migrate/20181113182615_add_vms_table.rb
@@ -5,7 +5,7 @@ class AddVmsTable < ActiveRecord::Migration[5.1]
       t.references :source, :type => :bigint, :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
 
       t.string :source_ref
-      t.string :uuid
+      t.string :uid_ems
       t.string :name
       t.string :hostname
       t.string :description
@@ -26,7 +26,7 @@ class AddVmsTable < ActiveRecord::Migration[5.1]
 
       t.index [:source_id, :source_ref], :unique => true
       t.index :archived_on
-      t.index :uuid
+      t.index :uid_ems
     end
   end
 end

--- a/db/migrate/20181113182615_add_vms_table.rb
+++ b/db/migrate/20181113182615_add_vms_table.rb
@@ -13,6 +13,8 @@ class AddVmsTable < ActiveRecord::Migration[5.1]
       t.bigint :cpus
       t.bigint :memory
 
+      t.jsonb :extra
+
       t.datetime :resource_timestamp
       t.jsonb    :resource_timestamps, default: {}
       t.datetime :resource_timestamps_max

--- a/db/migrate/20181113182615_add_vms_table.rb
+++ b/db/migrate/20181113182615_add_vms_table.rb
@@ -1,0 +1,26 @@
+class AddVmsTable < ActiveRecord::Migration[5.1]
+  def change
+    create_table :vms do |t|
+      t.references :tenant, :type => :bigint, :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.references :source, :type => :bigint, :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+
+      t.string :source_ref
+      t.string :uuid
+      t.string :vendor
+      t.string :name
+      t.string :hostname
+      t.string :description
+      t.string :power_state
+      t.bigint :cpus
+      t.bigint :memory
+
+      t.timestamps
+      t.datetime :archived_at
+      t.datetime :source_created_at
+      t.datetime :source_deleted_at
+
+      t.index [:source_id, :source_ref], :unique => true
+      t.index :archived_at
+    end
+  end
+end

--- a/db/migrate/20181113182615_add_vms_table.rb
+++ b/db/migrate/20181113182615_add_vms_table.rb
@@ -14,6 +14,10 @@ class AddVmsTable < ActiveRecord::Migration[5.1]
       t.bigint :cpus
       t.bigint :memory
 
+      t.datetime :resource_timestamp
+      t.jsonb    :resource_timestamps, default: {}
+      t.datetime :resource_timestamps_max
+
       t.timestamps
       t.datetime :archived_at
       t.datetime :source_created_at

--- a/db/migrate/20181113182615_add_vms_table.rb
+++ b/db/migrate/20181113182615_add_vms_table.rb
@@ -6,7 +6,6 @@ class AddVmsTable < ActiveRecord::Migration[5.1]
 
       t.string :source_ref
       t.string :uuid
-      t.string :vendor
       t.string :name
       t.string :hostname
       t.string :description

--- a/db/migrate/20181113182615_add_vms_table.rb
+++ b/db/migrate/20181113182615_add_vms_table.rb
@@ -26,6 +26,7 @@ class AddVmsTable < ActiveRecord::Migration[5.1]
 
       t.index [:source_id, :source_ref], :unique => true
       t.index :archived_on
+      t.index :uuid
     end
   end
 end

--- a/db/migrate/20181113182615_add_vms_table.rb
+++ b/db/migrate/20181113182615_add_vms_table.rb
@@ -20,12 +20,12 @@ class AddVmsTable < ActiveRecord::Migration[5.1]
       t.datetime :resource_timestamps_max
 
       t.timestamps
-      t.datetime :archived_at
+      t.datetime :archived_on
       t.datetime :source_created_at
       t.datetime :source_deleted_at
 
       t.index [:source_id, :source_ref], :unique => true
-      t.index :archived_at
+      t.index :archived_on
     end
   end
 end

--- a/db/migrate/20181113190507_add_orchestration_stacks.rb
+++ b/db/migrate/20181113190507_add_orchestration_stacks.rb
@@ -13,12 +13,12 @@ class AddOrchestrationStacks < ActiveRecord::Migration[5.1]
       t.datetime :resource_timestamps_max
 
       t.timestamps
-      t.datetime :archived_at
+      t.datetime :archived_on
       t.datetime :source_created_at
       t.datetime :source_deleted_at
 
       t.index [:source_id, :source_ref], :unique => true
-      t.index :archived_at
+      t.index :archived_on
     end
 
     add_reference :vms, :orchestration_stack, :index => true, :foreign_key => {:on_delete => :nullify}

--- a/db/migrate/20181113190507_add_orchestration_stacks.rb
+++ b/db/migrate/20181113190507_add_orchestration_stacks.rb
@@ -1,0 +1,22 @@
+class AddOrchestrationStacks < ActiveRecord::Migration[5.1]
+  def change
+    create_table :orchestration_stacks do |t|
+      t.references :tenant, :type => :bigint, :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+      t.references :source, :type => :bigint, :index => true, :null => false, :foreign_key => {:on_delete => :cascade}
+
+      t.string :source_ref
+      t.string :name
+      t.string :description
+
+      t.timestamps
+      t.datetime :archived_at
+      t.datetime :source_created_at
+      t.datetime :source_deleted_at
+
+      t.index [:source_id, :source_ref], :unique => true
+      t.index :archived_at
+    end
+
+    add_reference :vms, :orchestration_stack, :index => true, :foreign_key => {:on_delete => :nullify}
+  end
+end

--- a/db/migrate/20181113190507_add_orchestration_stacks.rb
+++ b/db/migrate/20181113190507_add_orchestration_stacks.rb
@@ -8,6 +8,10 @@ class AddOrchestrationStacks < ActiveRecord::Migration[5.1]
       t.string :name
       t.string :description
 
+      t.datetime :resource_timestamp
+      t.jsonb    :resource_timestamps, default: {}
+      t.datetime :resource_timestamps_max
+
       t.timestamps
       t.datetime :archived_at
       t.datetime :source_created_at

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -167,10 +167,10 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.datetime "resource_timestamps_max"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "archived_at"
+    t.datetime "archived_on"
     t.datetime "source_created_at"
     t.datetime "source_deleted_at"
-    t.index ["archived_at"], name: "index_orchestration_stacks_on_archived_at"
+    t.index ["archived_on"], name: "index_orchestration_stacks_on_archived_on"
     t.index ["source_id", "source_ref"], name: "index_orchestration_stacks_on_source_id_and_source_ref", unique: true
     t.index ["source_id"], name: "index_orchestration_stacks_on_source_id"
     t.index ["tenant_id"], name: "index_orchestration_stacks_on_tenant_id"
@@ -368,11 +368,11 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.datetime "resource_timestamps_max"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.datetime "archived_at"
+    t.datetime "archived_on"
     t.datetime "source_created_at"
     t.datetime "source_deleted_at"
     t.bigint "orchestration_stack_id"
-    t.index ["archived_at"], name: "index_vms_on_archived_at"
+    t.index ["archived_on"], name: "index_vms_on_archived_on"
     t.index ["orchestration_stack_id"], name: "index_vms_on_orchestration_stack_id"
     t.index ["source_id", "source_ref"], name: "index_vms_on_source_id_and_source_ref", unique: true
     t.index ["source_id"], name: "index_vms_on_source_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -355,7 +355,7 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.bigint "tenant_id", null: false
     t.bigint "source_id", null: false
     t.string "source_ref"
-    t.string "uuid"
+    t.string "uid_ems"
     t.string "name"
     t.string "hostname"
     t.string "description"
@@ -377,7 +377,7 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.index ["source_id", "source_ref"], name: "index_vms_on_source_id_and_source_ref", unique: true
     t.index ["source_id"], name: "index_vms_on_source_id"
     t.index ["tenant_id"], name: "index_vms_on_tenant_id"
-    t.index ["uuid"], name: "index_vms_on_uuid"
+    t.index ["uid_ems"], name: "index_vms_on_uid_ems"
   end
 
   add_foreign_key "authentications", "tenants", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -162,6 +162,9 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.string "source_ref"
     t.string "name"
     t.string "description"
+    t.datetime "resource_timestamp"
+    t.jsonb "resource_timestamps", default: {}
+    t.datetime "resource_timestamps_max"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "archived_at"
@@ -360,6 +363,9 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.string "power_state"
     t.bigint "cpus"
     t.bigint "memory"
+    t.datetime "resource_timestamp"
+    t.jsonb "resource_timestamps", default: {}
+    t.datetime "resource_timestamps_max"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.datetime "archived_at"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181113145803) do
+ActiveRecord::Schema.define(version: 20181113182615) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -331,6 +331,29 @@ ActiveRecord::Schema.define(version: 20181113145803) do
     t.datetime "updated_at", null: false
   end
 
+  create_table "vms", force: :cascade do |t|
+    t.bigint "tenant_id", null: false
+    t.bigint "source_id", null: false
+    t.string "source_ref"
+    t.string "uuid"
+    t.string "vendor"
+    t.string "name"
+    t.string "hostname"
+    t.string "description"
+    t.string "power_state"
+    t.bigint "cpus"
+    t.bigint "memory"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "archived_at"
+    t.datetime "source_created_at"
+    t.datetime "source_deleted_at"
+    t.index ["archived_at"], name: "index_vms_on_archived_at"
+    t.index ["source_id", "source_ref"], name: "index_vms_on_source_id_and_source_ref", unique: true
+    t.index ["source_id"], name: "index_vms_on_source_id"
+    t.index ["tenant_id"], name: "index_vms_on_tenant_id"
+  end
+
   add_foreign_key "authentications", "tenants", on_delete: :cascade
   add_foreign_key "container_groups", "container_nodes", on_delete: :cascade
   add_foreign_key "container_groups", "container_projects", on_delete: :cascade
@@ -368,4 +391,6 @@ ActiveRecord::Schema.define(version: 20181113145803) do
   add_foreign_key "sources", "tenants", on_delete: :cascade
   add_foreign_key "subscriptions", "sources", on_delete: :cascade
   add_foreign_key "subscriptions", "tenants", on_delete: :cascade
+  add_foreign_key "vms", "sources", on_delete: :cascade
+  add_foreign_key "vms", "tenants", on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -362,6 +362,7 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.string "power_state"
     t.bigint "cpus"
     t.bigint "memory"
+    t.jsonb "extra"
     t.datetime "resource_timestamp"
     t.jsonb "resource_timestamps", default: {}
     t.datetime "resource_timestamps_max"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20181113182615) do
+ActiveRecord::Schema.define(version: 20181113190507) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -154,6 +154,23 @@ ActiveRecord::Schema.define(version: 20181113182615) do
     t.boolean "verify_ssl"
     t.text "certificate_authority"
     t.index ["source_id"], name: "index_endpoints_on_source_id"
+  end
+
+  create_table "orchestration_stacks", force: :cascade do |t|
+    t.bigint "tenant_id", null: false
+    t.bigint "source_id", null: false
+    t.string "source_ref"
+    t.string "name"
+    t.string "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.datetime "archived_at"
+    t.datetime "source_created_at"
+    t.datetime "source_deleted_at"
+    t.index ["archived_at"], name: "index_orchestration_stacks_on_archived_at"
+    t.index ["source_id", "source_ref"], name: "index_orchestration_stacks_on_source_id_and_source_ref", unique: true
+    t.index ["source_id"], name: "index_orchestration_stacks_on_source_id"
+    t.index ["tenant_id"], name: "index_orchestration_stacks_on_tenant_id"
   end
 
   create_table "service_instances", force: :cascade do |t|
@@ -348,7 +365,9 @@ ActiveRecord::Schema.define(version: 20181113182615) do
     t.datetime "archived_at"
     t.datetime "source_created_at"
     t.datetime "source_deleted_at"
+    t.bigint "orchestration_stack_id"
     t.index ["archived_at"], name: "index_vms_on_archived_at"
+    t.index ["orchestration_stack_id"], name: "index_vms_on_orchestration_stack_id"
     t.index ["source_id", "source_ref"], name: "index_vms_on_source_id_and_source_ref", unique: true
     t.index ["source_id"], name: "index_vms_on_source_id"
     t.index ["tenant_id"], name: "index_vms_on_tenant_id"
@@ -370,6 +389,8 @@ ActiveRecord::Schema.define(version: 20181113182615) do
   add_foreign_key "containers", "tenants", on_delete: :cascade
   add_foreign_key "endpoints", "sources", on_delete: :cascade
   add_foreign_key "endpoints", "tenants", on_delete: :cascade
+  add_foreign_key "orchestration_stacks", "sources", on_delete: :cascade
+  add_foreign_key "orchestration_stacks", "tenants", on_delete: :cascade
   add_foreign_key "service_instances", "service_offerings", on_delete: :nullify
   add_foreign_key "service_instances", "service_plans", on_delete: :nullify
   add_foreign_key "service_instances", "source_regions", on_delete: :cascade
@@ -391,6 +412,7 @@ ActiveRecord::Schema.define(version: 20181113182615) do
   add_foreign_key "sources", "tenants", on_delete: :cascade
   add_foreign_key "subscriptions", "sources", on_delete: :cascade
   add_foreign_key "subscriptions", "tenants", on_delete: :cascade
+  add_foreign_key "vms", "orchestration_stacks", on_delete: :nullify
   add_foreign_key "vms", "sources", on_delete: :cascade
   add_foreign_key "vms", "tenants", on_delete: :cascade
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -377,6 +377,7 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.index ["source_id", "source_ref"], name: "index_vms_on_source_id_and_source_ref", unique: true
     t.index ["source_id"], name: "index_vms_on_source_id"
     t.index ["tenant_id"], name: "index_vms_on_tenant_id"
+    t.index ["uuid"], name: "index_vms_on_uuid"
   end
 
   add_foreign_key "authentications", "tenants", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -356,7 +356,6 @@ ActiveRecord::Schema.define(version: 20181113190507) do
     t.bigint "source_id", null: false
     t.string "source_ref"
     t.string "uuid"
-    t.string "vendor"
     t.string "name"
     t.string "hostname"
     t.string "description"


### PR DESCRIPTION
Adds models for Vms and OrchestrationStacks for AWS inventory.

I left out a `:template` from the vms table with the theory that we'll have separate tables for vms and templates.