### PR TITLE
Vm#orchestration_stack is an optional parameter

### DIFF
--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -5,7 +5,7 @@ class Vm < ApplicationRecord
 
   belongs_to :tenant
   belongs_to :source
-  belongs_to :orchestration_stack
+  belongs_to :orchestration_stack, :optional => true
 
   acts_as_taggable
 end


### PR DESCRIPTION
Allow vm#orchestration_stack to be null matching the database schema.