### PR TITLE
Use real auth object for service_catalog_client_spec

### DIFF
--- a/app/models/concerns/password_concern.rb
+++ b/app/models/concerns/password_concern.rb
@@ -1,3 +1,5 @@
+require "manageiq/password"
+
 module PasswordConcern
   extend ActiveSupport::Concern
 

--- a/app/models/service_plan.rb
+++ b/app/models/service_plan.rb
@@ -18,7 +18,7 @@ class ServicePlan < ApplicationRecord
     parsed_response = service_catalog_client.order_service_plan(name, service_offering.name, additional_parameters)
 
     task = Task.create!(
-      :tenant => tenant,
+      :tenant  => tenant,
       :context => {
         :service_instance => {
           :source_id  => source.id,

--- a/spec/models/service_plan_spec.rb
+++ b/spec/models/service_plan_spec.rb
@@ -33,7 +33,7 @@ describe ServicePlan do
 
     it "creates a task with context information" do
       service_plan.order(parameters)
-      expect(Task.last.context).to eq({"service_instance" => {"source_id" => source.id, "source_ref" => 321}})
+      expect(Task.last.context).to eq("service_instance" => {"source_id" => source.id, "source_ref" => 321})
     end
 
     it "returns the task id" do

--- a/spec/topological_inventory/core/service_catalog_client_spec.rb
+++ b/spec/topological_inventory/core/service_catalog_client_spec.rb
@@ -3,15 +3,10 @@ module TopologicalInventory
     describe ServiceCatalogClient do
       let(:subject) { described_class.new(source) }
 
-      let(:endpoint) do
-        # TODO: Use real Authentication
-        # Endpoint.new(:default => true, :verify_ssl => true, :authentications => [auth])
-        Endpoint.new(:default => true, :verify_ssl => verify_ssl)
-      end
-      # TODO: Use real Authentication
-      # let(:auth) { Authentication.create!(:password => "token") }
-      let(:auth) { instance_double("Authentication", :password => "token") }
+      let(:endpoint) { Endpoint.new(:default => true, :verify_ssl => verify_ssl, :authentications => [auth]) }
+      let(:auth) { Authentication.create!(:tenant => tenant, :password => "token") }
       let(:source) { Source.new(:endpoints => [endpoint]) }
+      let(:tenant) { Tenant.create! }
 
       describe "#order_service_plan" do
         let(:url) do

--- a/spec/topological_inventory/core/service_catalog_client_spec.rb
+++ b/spec/topological_inventory/core/service_catalog_client_spec.rb
@@ -29,8 +29,8 @@ module TopologicalInventory
             "plan_name", "service_offering_name", additional_parameters
           ).and_return("payload")
 
-          stub_request(:post, url).with(:body => "payload", :headers => headers).
-            to_return(:body => dummy_response.to_json)
+          stub_request(:post, url).with(:body => "payload", :headers => headers)
+            .to_return(:body => dummy_response.to_json)
 
           allow(endpoint).to receive(:authentications).and_return([auth])
           allow(endpoint).to receive(:base_url_path).and_return("https://example.com")
@@ -46,7 +46,7 @@ module TopologicalInventory
 
           it "builds the payload" do
             expect(service_plan_client).to receive(:build_payload).with(
-              "plan_name", "service_offering_name", {"foo" => "bar", "baz" => "qux"}
+              "plan_name", "service_offering_name", "foo" => "bar", "baz" => "qux"
             )
 
             subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)
@@ -69,7 +69,7 @@ module TopologicalInventory
 
           it "builds the payload" do
             expect(service_plan_client).to receive(:build_payload).with(
-              "plan_name", "service_offering_name", {"foo" => "bar", "baz" => "qux"}
+              "plan_name", "service_offering_name", "foo" => "bar", "baz" => "qux"
             )
 
             subject.order_service_plan("plan_name", "service_offering_name", additional_parameters)


### PR DESCRIPTION
As @bdunne requested, the `service_catalog_client_spec` now uses a real Authentication object. In order for specs to pass, however, I needed to add the `require "manageiq/password"` to `password_concern.rb`, otherwise I was simply getting errors when trying to run the test.

I was also getting errors until I had a `v2_key` in my root project directory, so hopefully travis has this otherwise we might see issues there as well.