### PR TITLE
Allow externally setting database yaml path

### DIFF
--- a/lib/topological_inventory/core/ar_helper.rb
+++ b/lib/topological_inventory/core/ar_helper.rb
@@ -1,11 +1,18 @@
 module TopologicalInventory
   module Core
     module ArHelper
+      def self.database_yaml_path
+        @database_yaml_path ||= root.join("config", "database.yml")
+      end
+
+      def self.database_yaml_path=(path)
+        @database_yaml_path = path
+      end
+
       def self.load_environment!
         ENV["RAILS_ENV"] ||= "development"
 
         require "yaml"
-        database_yaml_path = root.join("config", "database.yml")
         database_yaml = YAML.load_file(database_yaml_path) if database_yaml_path.exist?
 
         require "active_record"


### PR DESCRIPTION
This is needed by things that will use this repo as a dependency since
the database.yml will not live in the gem directory.  Thus, the caller
can specify their own database.yml path.  An example usage from
topological_inventory-persister would be:

```ruby
  # Rakefile
  require "topological_inventory/core/ar_helper"
  TopologicalInventory::Core::ArHelper.database_yaml_path = Pathname.new(__dir__).join("config/database.yml")
  TopologicalInventory::Core::ArHelper.load_environment!
```
e665c25

@agrare Please review.