### PR TITLE
Fix a couple last references to archived_on

### DIFF
--- a/app/models/concerns/archived_concern.rb
+++ b/app/models/concerns/archived_concern.rb
@@ -2,8 +2,8 @@ module ArchivedConcern
   extend ActiveSupport::Concern
 
   included do
-    scope :archived, -> { where.not(:archived_on => nil) }
-    scope :active,   -> { where(:archived_on => nil) }
+    scope :archived, -> { where.not(:archived_at => nil) }
+    scope :active,   -> { where(:archived_at => nil) }
   end
 
   def archived?


### PR DESCRIPTION
Missed a couple of archived_on references renamed in
https://github.com/ManageIQ/topological_inventory-core/pull/72