### PR TITLE
Set autoload_paths for core models and concerns

### DIFF
--- a/lib/topological_inventory/core/ar_helper.rb
+++ b/lib/topological_inventory/core/ar_helper.rb
@@ -35,6 +35,9 @@ module TopologicalInventory
         $LOAD_PATH << root.join("app", "models")
         $LOAD_PATH << root.join("app", "models", "concerns")
 
+        ActiveSupport::Dependencies.autoload_paths << root.join("app", "models")
+        ActiveSupport::Dependencies.autoload_paths << root.join("app", "models", "concenrs")
+
         require "application_record"
         Dir[root.join("app/models/**/*.rb")].each { |f| require f }
       end


### PR DESCRIPTION
Fix for the errors in https://github.com/ManageIQ/topological_inventory-core/pull/76 where acts_as_tenant checking inflections on first require before other models are required 