### PR TITLE
Don't send template parameters with empty values

### DIFF
--- a/lib/topological_inventory/core/service_plan_client.rb
+++ b/lib/topological_inventory/core/service_plan_client.rb
@@ -1,7 +1,14 @@
+require 'more_core_extensions/core_ext/hash'
+
 module TopologicalInventory
   module Core
     class ServicePlanClient
       def build_payload(service_plan_name, service_offering_name, order_parameters)
+        # We need to not send empty strings in case the parameter is generated
+        # More details are explained in the comment in the OpenShift web catalog
+        # https://github.com/openshift/origin-web-catalog/blob/4c5cb3ee1ae0061ed28fc6190a0f8fff71771122/src/components/order-service/order-service.controller.ts#L442
+        safe_params = order_parameters[:service_parameters].delete_blanks
+
         {
           "apiVersion" => "servicecatalog.k8s.io/v1beta1",
           "kind"       => "ServiceInstance",
@@ -12,7 +19,7 @@ module TopologicalInventory
           "spec"       => {
             "clusterServiceClassExternalName" => service_offering_name,
             "clusterServicePlanExternalName"  => service_plan_name,
-            "parameters"                      => order_parameters[:service_parameters]
+            "parameters"                      => safe_params
           }
         }.to_json
       end

--- a/spec/topological_inventory/core/service_plan_client_spec.rb
+++ b/spec/topological_inventory/core/service_plan_client_spec.rb
@@ -10,7 +10,7 @@ module TopologicalInventory
             :provider_control_parameters => {:namespace => "namespace"}
           }
         end
-        let(:service_parameters) { {"DB_NAME" => "TEST_DB", "namespace" => "TEST_DB_NAMESPACE"} }
+        let(:service_parameters) { {"DB_NAME" => "TEST_DB", "namespace" => "TEST_DB_NAMESPACE", "EMPTY" => ""} }
         let(:expected_payload) do
           {
             "apiVersion" => "servicecatalog.k8s.io/v1beta1",
@@ -22,7 +22,7 @@ module TopologicalInventory
             "spec"       => {
               "clusterServiceClassExternalName" => "service_offering_name",
               "clusterServicePlanExternalName"  => "service_plan_name",
-              "parameters"                      => service_parameters
+              "parameters"                      => {"DB_NAME" => "TEST_DB", "namespace" => "TEST_DB_NAMESPACE"}
             }
           }.to_json
         end

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -20,6 +20,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "acts_as_tenant"
   s.add_runtime_dependency "manageiq-messaging", "~> 0.1.0"
   s.add_runtime_dependency "manageiq-password",  "~> 0.2"
+  s.add_runtime_dependency "more_core_extensions"
   s.add_runtime_dependency "pg", "> 0"
   s.add_runtime_dependency "rails", "~> 5.2", ">= 5.2.1.1"
   s.add_runtime_dependency "rest-client", ">= 1.8.0"


### PR DESCRIPTION
Parameters which are not set by the user in the service portal
dialog are being sent to us as empty strings. We should not be sending
those parameters over to OpenShift. This is the way the OpenShift
catalog UI handles the case when a user doesn't fill in a non-required
parameter.

See https://github.com/openshift/origin/issues/21769 for full details of the error case.
cc @eclarizio 