### PR TITLE
Modeling features availabilities

### DIFF
--- a/app/models/availability.rb
+++ b/app/models/availability.rb
@@ -1,0 +1,3 @@
+class Availability < ApplicationRecord
+  belongs_to :resource, :polymorphic => true
+end

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,5 +1,7 @@
 class Source < ApplicationRecord
   has_many :endpoints, :autosave => true
+  has_many :availabilities, :as => :resource, :dependent => :destroy
+
   belongs_to :source_type
   belongs_to :tenant
 

--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -1,6 +1,6 @@
 class Source < ApplicationRecord
   has_many :endpoints, :autosave => true
-  has_many :availabilities, :as => :resource, :dependent => :destroy
+  has_many :availabilities, :as => :resource, :dependent => :destroy, :inverse_of => :resource
 
   belongs_to :source_type
   belongs_to :tenant

--- a/app/models/source_type.rb
+++ b/app/models/source_type.rb
@@ -1,3 +1,4 @@
 class SourceType < ApplicationRecord
   has_many :sources
+  has_many :availabilities, :as => :resource, :dependent => :destroy
 end

--- a/app/models/source_type.rb
+++ b/app/models/source_type.rb
@@ -1,4 +1,4 @@
 class SourceType < ApplicationRecord
   has_many :sources
-  has_many :availabilities, :as => :resource, :dependent => :destroy
+  has_many :availabilities, :as => :resource, :dependent => :destroy, :inverse_of => :resource
 end

--- a/db/migrate/20190208143909_add_availabilities_table.rb
+++ b/db/migrate/20190208143909_add_availabilities_table.rb
@@ -1,7 +1,7 @@
 class AddAvailabilitiesTable < ActiveRecord::Migration[5.2]
   def change
     create_table :availabilities, :id => :bigserial, :force => :cascade do |t|
-      t.references :resource,     :polymorphic => true, :index => false
+      t.references :resource,     :polymorphic => true, :index => false, :null => false
       t.string     :action,       :null => false
       t.string     :identifier,   :null => false
       t.string     :availability, :null => false

--- a/db/migrate/20190208143909_add_availabilities_table.rb
+++ b/db/migrate/20190208143909_add_availabilities_table.rb
@@ -8,6 +8,8 @@ class AddAvailabilitiesTable < ActiveRecord::Migration[5.2]
       t.datetime   :last_checked_at
       t.datetime   :last_valid_at
       t.timestamps
+      t.index      [:resource_type, :resource_id, :action, :identifier], :unique => true,
+                   :name => :index_on_resource_action_identifier
     end
   end
 end

--- a/db/migrate/20190208143909_add_availabilities_table.rb
+++ b/db/migrate/20190208143909_add_availabilities_table.rb
@@ -1,0 +1,13 @@
+class AddAvailabilitiesTable < ActiveRecord::Migration[5.2]
+  def change
+    create_table :availabilities, :id => :bigserial, :force => :cascade do |t|
+      t.references :resource,     :polymorphic => true, :index => false
+      t.string     :action,       :null => false
+      t.string     :identifier,   :null => false
+      t.string     :availability, :null => false
+      t.datetime   :last_checked_at
+      t.datetime   :last_valid_at
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -29,6 +29,18 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.index ["tenant_id"], name: "index_authentications_on_tenant_id"
   end
 
+  create_table "availabilities", force: :cascade do |t|
+    t.string "resource_type"
+    t.bigint "resource_id"
+    t.string "action", null: false
+    t.string "identifier", null: false
+    t.string "availability", null: false
+    t.datetime "last_checked_at"
+    t.datetime "last_valid_at"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
   create_table "container_group_tags", id: :serial, force: :cascade do |t|
     t.bigint "tenant_id", null: false
     t.bigint "tag_id", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -30,8 +30,8 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
   end
 
   create_table "availabilities", force: :cascade do |t|
-    t.string "resource_type"
-    t.bigint "resource_id"
+    t.string "resource_type", null: false
+    t.bigint "resource_id", null: false
     t.string "action", null: false
     t.string "identifier", null: false
     t.string "availability", null: false

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,6 +39,7 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.datetime "last_valid_at"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["resource_type", "resource_id", "action", "identifier"], name: "index_on_resource_action_identifier", unique: true
   end
 
   create_table "container_group_tags", id: :serial, force: :cascade do |t|


### PR DESCRIPTION
Add a table to track the support and availability of features of resources/actions based on API path.

```
>> openshift_source = Source.create!(:tenant => tenant, :source_type => openshift_source_type, :name => "OCP", :uid => SecureRandom.uuid)
>> openshift_source.availabilities.create!(:action => "GET", :identifier => "/service_instances", :availability => "available", :last_valid_at => Time.now.utc, :last_checked_at => Time.now.utc)
>> openshift_source.availabilities.create!(:action => "GET", :identifier => "/service_offerings", :availability => "available", :last_valid_at => Time.now.utc, :last_checked_at => Time.now.utc)
>> openshift_source.availabilities.create!(:action => "GET", :identifier => "/service_plans", :availability => "available", :last_valid_at => Time.now.utc, :last_checked_at => Time.now.utc)
>> openshift_source.availabilities.create!(:action => "POST", :identifier => "/service_plans#order", :availability => "available", :last_valid_at => Time.now.utc, :last_checked_at => Time.now.utc)
```

Possible values for availability: `["unsupported", "supported", "unavailable", "available"]`

This lets users check if a feature is available in a source-type agnostic way:
```
>> openshift_source.availabilities.find_by(:action => "POST", :identifier => "/service_plans#order").availability == "available"
=> true
```

This also allows the provider to update feature availability if e.g. the servicebroker endpoint isn't enabled on the source.