### PR TITLE
Remove belongs_to :source from tag tables

### DIFF
--- a/app/models/container_group_tag.rb
+++ b/app/models/container_group_tag.rb
@@ -1,6 +1,5 @@
 class ContainerGroupTag < ApplicationRecord
   belongs_to :tenant
-  belongs_to :source
 
   belongs_to :container_group
   belongs_to :tag

--- a/app/models/container_image_tag.rb
+++ b/app/models/container_image_tag.rb
@@ -1,6 +1,5 @@
 class ContainerImageTag < ApplicationRecord
   belongs_to :tenant
-  belongs_to :source
 
   belongs_to :container_image
   belongs_to :tag

--- a/app/models/container_node_tag.rb
+++ b/app/models/container_node_tag.rb
@@ -1,6 +1,5 @@
 class ContainerNodeTag < ApplicationRecord
   belongs_to :tenant
-  belongs_to :source
 
   belongs_to :container_node
   belongs_to :tag

--- a/app/models/container_project_tag.rb
+++ b/app/models/container_project_tag.rb
@@ -1,6 +1,5 @@
 class ContainerProjectTag < ApplicationRecord
   belongs_to :tenant
-  belongs_to :source
 
   belongs_to :container_project
   belongs_to :tag

--- a/app/models/container_template_tag.rb
+++ b/app/models/container_template_tag.rb
@@ -1,6 +1,5 @@
 class ContainerTemplateTag < ApplicationRecord
   belongs_to :tenant
-  belongs_to :source
 
   belongs_to :container_template
   belongs_to :tag

--- a/app/models/service_offering_tag.rb
+++ b/app/models/service_offering_tag.rb
@@ -1,6 +1,5 @@
 class ServiceOfferingTag < ApplicationRecord
   belongs_to :tenant
-  belongs_to :source
 
   belongs_to :service_offering
   belongs_to :tag


### PR DESCRIPTION
`belongs_to :source`s were added here https://github.com/ManageIQ/topological_inventory-core/pull/83.

Tables `XXX_tags` are for establishing M:N relations between `XXXs` and `tags` table but they don't need relation to `sources` table.

cc @gtanzillo 

@miq-bot assign @Ladas 

