### PR TITLE
Define retention strategy destroy for non archivable

### DIFF
--- a/app/models/vm.rb
+++ b/app/models/vm.rb
@@ -8,8 +8,8 @@ class Vm < ApplicationRecord
   belongs_to :orchestration_stack, :optional => true
   belongs_to :flavor, :optional => true
 
-  has_many :volumes, :through => :volume_attachments
   has_many :volume_attachments
+  has_many :volumes, :through => :volume_attachments
 
   acts_as_tenant(:tenant)
   acts_as_taggable_on

--- a/lib/topological_inventory/schema/default.rb
+++ b/lib/topological_inventory/schema/default.rb
@@ -74,9 +74,10 @@ module TopologicalInventory
         # TODO generate the manager_ref automatically?
         add_collection(model) do |builder|
           builder.add_properties(
-            :manager_ref    => manager_ref,
-            :strategy       => :local_db_find_missing_references,
-            :saver_strategy => :concurrent_safe_batch,
+            :manager_ref        => manager_ref,
+            :strategy           => :local_db_find_missing_references,
+            :saver_strategy     => :concurrent_safe_batch,
+            :retention_strategy => :destroy,
           )
 
           builder.add_default_values(
@@ -95,6 +96,7 @@ module TopologicalInventory
       def add_volume_attachments
         add_collection(:volume_attachments) do |builder|
           add_default_properties(builder, manager_ref: [:volume, :vm])
+          builder.add_properties(:retention_strategy => :destroy)
           builder.add_default_values(:tenant_id => ->(persister) { persister.manager.tenant_id })
         end
       end


### PR DESCRIPTION
Without defining the right strategy, the ICs are failing to archive entities.