### PR TITLE
[WIP] Use db triggers for tag cascade deletions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,9 @@ gemspec
 
 gem "inventory_refresh", :git => "https://github.com/ManageIQ/inventory_refresh", :branch => "master"
 
+# Until https://github.com/ErwinM/acts_as_tenant/pull/192 is released
+gem "acts_as_tenant", :git => "https://github.com/ErwinM/acts_as_tenant", :branch => "master"
+
 #
 # Custom Gemfile modifications
 #

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,9 @@ require "yaml"
 
 load "active_record/railties/databases.rake"
 
+require "hair_trigger"
+load "tasks/hair_trigger.rake"
+
 namespace :db do
   task :environment do
     require "topological_inventory/core/ar_helper"

--- a/Rakefile
+++ b/Rakefile
@@ -28,6 +28,7 @@ require "hair_trigger"
 load "tasks/hair_trigger.rake"
 
 namespace :db do
+  ENV["SCHEMA"] ||= "db/schema.rb"
   task :environment do
     require "topological_inventory/core/ar_helper"
     TopologicalInventory::Core::ArHelper.load_environment!

--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,13 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
-  # Hack for running acts_as_tenant in a non Rails env.
-  # See https://github.com/ErwinM/acts_as_tenant/pull/192 for proposed fix
-  begin
-    module ::Rails
-      module VERSION
-        MAJOR = ActiveRecord::VERSION::MAJOR
-      end
-    end
-  end if !defined?(::Rails) || !::Rails.const_defined?("VERSION")
   require 'acts_as_tenant'
 
   self.abstract_class = true

--- a/app/models/concerns/act_as_taggable_on.rb
+++ b/app/models/concerns/act_as_taggable_on.rb
@@ -7,7 +7,7 @@ module ActAsTaggableOn
         "taggings".to_sym
       end
 
-      has_many tagging_relation_name, :as => :resource
+      has_many tagging_relation_name, :as => :resource, :inverse_of => :resource
       has_many :tags, :through => tagging_relation_name
 
       def self.taggable?
@@ -15,7 +15,7 @@ module ActAsTaggableOn
       end
 
       trigger.after(:delete) do
-        "DELETE FROM taggings WHERE resource_type='#{self.name}' AND resource_id=OLD.id"
+        "DELETE FROM taggings WHERE resource_type='#{name}' AND resource_id=OLD.id"
       end
     end
   end

--- a/app/models/concerns/act_as_taggable_on.rb
+++ b/app/models/concerns/act_as_taggable_on.rb
@@ -3,19 +3,14 @@ module ActAsTaggableOn
     class_eval do
       require "hair_trigger"
 
-      def self.tagging_relation_name
-        "taggings".to_sym
-      end
-
-      has_many tagging_relation_name, :as => :resource, :inverse_of => :resource
-      has_many :tags, :through => tagging_relation_name
+      has_many :tags, :as => :resource
 
       def self.taggable?
         true
       end
 
       trigger.after(:delete) do
-        "DELETE FROM taggings WHERE resource_type='#{name}' AND resource_id=OLD.id"
+        "DELETE FROM tags WHERE resource_type='#{name}' AND resource_id=OLD.id"
       end
     end
   end

--- a/app/models/concerns/act_as_taggable_on.rb
+++ b/app/models/concerns/act_as_taggable_on.rb
@@ -2,24 +2,14 @@ module ActAsTaggableOn
   def acts_as_taggable_on
     class_eval do
       def self.tagging_relation_name
-        "#{name.underscore}_tags".to_sym
+        "taggings".to_sym
       end
 
-      has_many tagging_relation_name
+      has_many tagging_relation_name, :as => :resource
       has_many :tags, :through => tagging_relation_name
 
       def self.taggable?
         true
-      end
-
-      def taggings
-        public_send(self.class.tagging_relation_name).map do |tagging|
-          {
-            :tag_id => tagging.tag_id.to_s,
-            :name   => tagging.tag.name,
-            :value  => tagging.value,
-          }
-        end
       end
     end
   end

--- a/app/models/concerns/act_as_taggable_on.rb
+++ b/app/models/concerns/act_as_taggable_on.rb
@@ -1,6 +1,8 @@
 module ActAsTaggableOn
   def acts_as_taggable_on
     class_eval do
+      require "hair_trigger"
+
       def self.tagging_relation_name
         "taggings".to_sym
       end
@@ -10,6 +12,10 @@ module ActAsTaggableOn
 
       def self.taggable?
         true
+      end
+
+      trigger.after(:delete) do
+        "DELETE FROM taggings WHERE resource_type='#{self.name}' AND resource_id=OLD.id"
       end
     end
   end

--- a/app/models/container_group_tag.rb
+++ b/app/models/container_group_tag.rb
@@ -1,8 +1,0 @@
-class ContainerGroupTag < ApplicationRecord
-  belongs_to :tenant
-
-  belongs_to :container_group
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/app/models/container_image_tag.rb
+++ b/app/models/container_image_tag.rb
@@ -1,8 +1,0 @@
-class ContainerImageTag < ApplicationRecord
-  belongs_to :tenant
-
-  belongs_to :container_image
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/app/models/container_node_tag.rb
+++ b/app/models/container_node_tag.rb
@@ -1,8 +1,0 @@
-class ContainerNodeTag < ApplicationRecord
-  belongs_to :tenant
-
-  belongs_to :container_node
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/app/models/container_project_tag.rb
+++ b/app/models/container_project_tag.rb
@@ -1,8 +1,0 @@
-class ContainerProjectTag < ApplicationRecord
-  belongs_to :tenant
-
-  belongs_to :container_project
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/app/models/container_template_tag.rb
+++ b/app/models/container_template_tag.rb
@@ -1,8 +1,0 @@
-class ContainerTemplateTag < ApplicationRecord
-  belongs_to :tenant
-
-  belongs_to :container_template
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/app/models/service_offering_tag.rb
+++ b/app/models/service_offering_tag.rb
@@ -1,8 +1,0 @@
-class ServiceOfferingTag < ApplicationRecord
-  belongs_to :tenant
-
-  belongs_to :service_offering
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,23 +1,7 @@
 class Tag < ApplicationRecord
   belongs_to :tenant
 
-  has_many :container_group_tags
-  has_many :container_groups, :through => :container_group_tags
-
-  has_many :container_image_tags
-  has_many :container_images, :through => :container_image_tags
-
-  has_many :container_node_tags
-  has_many :container_nodes, :through => :container_node_tags
-
-  has_many :container_project_tags
-  has_many :container_projects, :through => :container_project_tags
-
-  has_many :container_template_tags
-  has_many :container_templates, :through => :container_template_tags
-
-  has_many :vm_tags
-  has_many :vms, :through => :vm_tags
+  has_many :taggings
 
   acts_as_tenant(:tenant)
 end

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,6 @@
 class Tag < ApplicationRecord
   belongs_to :tenant
-
-  has_many :taggings
+  belongs_to :resource, :polymorphic => true
 
   acts_as_tenant(:tenant)
 end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,6 +1,0 @@
-class Tagging < ApplicationRecord
-  belongs_to :resource, :polymorphic => true
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/app/models/tagging.rb
+++ b/app/models/tagging.rb
@@ -1,0 +1,6 @@
+class Tagging < ApplicationRecord
+  belongs_to :resource, :polymorphic => true
+  belongs_to :tag
+
+  acts_as_tenant(:tenant)
+end

--- a/app/models/vm_tag.rb
+++ b/app/models/vm_tag.rb
@@ -1,9 +1,0 @@
-class VmTag < ApplicationRecord
-  belongs_to :tenant
-  belongs_to :source
-
-  belongs_to :vm
-  belongs_to :tag
-
-  acts_as_tenant(:tenant)
-end

--- a/db/migrate/20190214170341_consolidate_intermediate_tag_tables.rb
+++ b/db/migrate/20190214170341_consolidate_intermediate_tag_tables.rb
@@ -1,0 +1,23 @@
+class ConsolidateIntermediateTagTables < ActiveRecord::Migration[5.2]
+  def up
+    create_table :taggings do |t|
+      t.references :tenant,   :null => false, :index => true
+      t.references :resource, :null => false, :index => true, :polymorphic => true
+      t.references :tag,      :null => false, :index => true
+      t.string     :value
+      t.timestamps
+    end
+
+    drop_table :container_group_tags
+    drop_table :container_image_tags
+    drop_table :container_node_tags
+    drop_table :container_project_tags
+    drop_table :container_template_tags
+    drop_table :service_offering_tags
+    drop_table :vm_tags
+  end
+
+  def down
+    drop_table :taggings
+  end
+end

--- a/db/migrate/20190214170341_consolidate_intermediate_tag_tables.rb
+++ b/db/migrate/20190214170341_consolidate_intermediate_tag_tables.rb
@@ -1,9 +1,9 @@
 class ConsolidateIntermediateTagTables < ActiveRecord::Migration[5.2]
   def up
     create_table :taggings do |t|
-      t.references :tenant,   :null => false, :index => true
+      t.references :tenant,   :null => false, :index => true, :foreign_key => {:on_delete => :cascade}
       t.references :resource, :null => false, :index => true, :polymorphic => true
-      t.references :tag,      :null => false, :index => true
+      t.references :tag,      :null => false, :index => true, :foreign_key => {:on_delete => :cascade}
       t.string     :value
       t.timestamps
     end

--- a/db/migrate/20190214185856_create_triggers_multiple_tables.rb
+++ b/db/migrate/20190214185856_create_triggers_multiple_tables.rb
@@ -1,0 +1,73 @@
+# This migration was auto-generated via `rake db:generate_trigger_migration'.
+# While you can edit this file, any changes you make to the definitions here
+# will be undone by the next auto-generated trigger migration.
+
+class CreateTriggersMultipleTables < ActiveRecord::Migration[5.2]
+  def up
+    create_trigger("container_groups_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("container_groups")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='ContainerGroup' AND resource_id=OLD.id;"
+    end
+
+    create_trigger("container_projects_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("container_projects")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='ContainerProject' AND resource_id=OLD.id;"
+    end
+
+    create_trigger("container_nodes_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("container_nodes")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='ContainerNode' AND resource_id=OLD.id;"
+    end
+
+    create_trigger("container_images_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("container_images")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='ContainerImage' AND resource_id=OLD.id;"
+    end
+
+    create_trigger("container_templates_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("container_templates")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='ContainerTemplate' AND resource_id=OLD.id;"
+    end
+
+    create_trigger("service_offerings_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("service_offerings")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
+    end
+
+    create_trigger("service_offerings_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("service_offerings")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
+    end
+
+    create_trigger("vms_after_delete_row_tr", :generated => true, :compatibility => 1)
+      .on("vms")
+      .after(:delete) do
+      "DELETE FROM taggings WHERE resource_type='Vm' AND resource_id=OLD.id;"
+    end
+  end
+
+  def down
+    drop_trigger("container_groups_after_delete_row_tr", "container_groups", :generated => true)
+
+    drop_trigger("container_projects_after_delete_row_tr", "container_projects", :generated => true)
+
+    drop_trigger("container_nodes_after_delete_row_tr", "container_nodes", :generated => true)
+
+    drop_trigger("container_images_after_delete_row_tr", "container_images", :generated => true)
+
+    drop_trigger("container_templates_after_delete_row_tr", "container_templates", :generated => true)
+
+    drop_trigger("service_offerings_after_delete_row_tr", "service_offerings", :generated => true)
+
+    drop_trigger("service_offerings_after_delete_row_tr", "service_offerings", :generated => true)
+
+    drop_trigger("vms_after_delete_row_tr", "vms", :generated => true)
+  end
+end

--- a/db/migrate/20190214185856_create_triggers_multiple_tables.rb
+++ b/db/migrate/20190214185856_create_triggers_multiple_tables.rb
@@ -7,49 +7,49 @@ class CreateTriggersMultipleTables < ActiveRecord::Migration[5.2]
     create_trigger("container_groups_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("container_groups")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='ContainerGroup' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='ContainerGroup' AND resource_id=OLD.id;"
     end
 
     create_trigger("container_projects_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("container_projects")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='ContainerProject' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='ContainerProject' AND resource_id=OLD.id;"
     end
 
     create_trigger("container_nodes_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("container_nodes")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='ContainerNode' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='ContainerNode' AND resource_id=OLD.id;"
     end
 
     create_trigger("container_images_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("container_images")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='ContainerImage' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='ContainerImage' AND resource_id=OLD.id;"
     end
 
     create_trigger("container_templates_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("container_templates")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='ContainerTemplate' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='ContainerTemplate' AND resource_id=OLD.id;"
     end
 
     create_trigger("service_offerings_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("service_offerings")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
     end
 
     create_trigger("service_offerings_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("service_offerings")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
     end
 
     create_trigger("vms_after_delete_row_tr", :generated => true, :compatibility => 1)
       .on("vms")
       .after(:delete) do
-      "DELETE FROM taggings WHERE resource_type='Vm' AND resource_id=OLD.id;"
+      "DELETE FROM tags WHERE resource_type='Vm' AND resource_id=OLD.id;"
     end
   end
 

--- a/db/migrate/20190215163236_collapse_taggings_and_tags.rb
+++ b/db/migrate/20190215163236_collapse_taggings_and_tags.rb
@@ -1,0 +1,9 @@
+class CollapseTaggingsAndTags < ActiveRecord::Migration[5.2]
+  def up
+    add_reference :tags, :resource, :null => false, :polymorphic => true
+    add_column    :tags, :value, :string
+    add_index     :tags, [:resource_type, :resource_id, :name], :unique => true
+
+    drop_table :taggings
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_15_133418) do
+ActiveRecord::Schema.define(version: 2019_02_15_163236) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -424,25 +424,17 @@ ActiveRecord::Schema.define(version: 2019_02_15_133418) do
     t.index ["tenant_id"], name: "index_subscriptions_on_tenant_id"
   end
 
-  create_table "taggings", force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.string "resource_type", null: false
-    t.bigint "resource_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["resource_type", "resource_id"], name: "index_taggings_on_resource_type_and_resource_id"
-    t.index ["tag_id"], name: "index_taggings_on_tag_id"
-    t.index ["tenant_id"], name: "index_taggings_on_tenant_id"
-  end
-
   create_table "tags", id: :serial, force: :cascade do |t|
     t.bigint "tenant_id", null: false
     t.string "name", null: false
     t.string "namespace", default: "", null: false
     t.text "description"
     t.datetime "created_at", null: false
+    t.string "resource_type", null: false
+    t.bigint "resource_id", null: false
+    t.string "value"
+    t.index ["resource_type", "resource_id", "name"], name: "index_tags_on_resource_type_and_resource_id_and_name", unique: true
+    t.index ["resource_type", "resource_id"], name: "index_tags_on_resource_type_and_resource_id"
     t.index ["tenant_id", "namespace", "name"], name: "index_tags_on_tenant_id_and_namespace_and_name", unique: true
   end
 
@@ -604,8 +596,6 @@ ActiveRecord::Schema.define(version: 2019_02_15_133418) do
   add_foreign_key "sources", "tenants", on_delete: :cascade
   add_foreign_key "subscriptions", "sources", on_delete: :cascade
   add_foreign_key "subscriptions", "tenants", on_delete: :cascade
-  add_foreign_key "taggings", "tags", on_delete: :cascade
-  add_foreign_key "taggings", "tenants", on_delete: :cascade
   add_foreign_key "tags", "tenants", on_delete: :cascade
   add_foreign_key "tasks", "tenants", on_delete: :cascade
   add_foreign_key "vms", "flavors", on_delete: :nullify
@@ -624,43 +614,43 @@ ActiveRecord::Schema.define(version: 2019_02_15_133418) do
   create_trigger("container_groups_after_delete_row_tr", :generated => true, :compatibility => 1).
       on("container_groups").
       after(:delete) do
-    "DELETE FROM taggings WHERE resource_type='ContainerGroup' AND resource_id=OLD.id;"
+    "DELETE FROM tags WHERE resource_type='ContainerGroup' AND resource_id=OLD.id;"
   end
 
   create_trigger("container_projects_after_delete_row_tr", :generated => true, :compatibility => 1).
       on("container_projects").
       after(:delete) do
-    "DELETE FROM taggings WHERE resource_type='ContainerProject' AND resource_id=OLD.id;"
+    "DELETE FROM tags WHERE resource_type='ContainerProject' AND resource_id=OLD.id;"
   end
 
   create_trigger("container_nodes_after_delete_row_tr", :generated => true, :compatibility => 1).
       on("container_nodes").
       after(:delete) do
-    "DELETE FROM taggings WHERE resource_type='ContainerNode' AND resource_id=OLD.id;"
+    "DELETE FROM tags WHERE resource_type='ContainerNode' AND resource_id=OLD.id;"
   end
 
   create_trigger("container_images_after_delete_row_tr", :generated => true, :compatibility => 1).
       on("container_images").
       after(:delete) do
-    "DELETE FROM taggings WHERE resource_type='ContainerImage' AND resource_id=OLD.id;"
+    "DELETE FROM tags WHERE resource_type='ContainerImage' AND resource_id=OLD.id;"
   end
 
   create_trigger("container_templates_after_delete_row_tr", :generated => true, :compatibility => 1).
       on("container_templates").
       after(:delete) do
-    "DELETE FROM taggings WHERE resource_type='ContainerTemplate' AND resource_id=OLD.id;"
+    "DELETE FROM tags WHERE resource_type='ContainerTemplate' AND resource_id=OLD.id;"
   end
 
   create_trigger("service_offerings_after_delete_row_tr", :generated => true, :compatibility => 1).
       on("service_offerings").
       after(:delete) do
-    "DELETE FROM taggings WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
+    "DELETE FROM tags WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
   end
 
   create_trigger("vms_after_delete_row_tr", :generated => true, :compatibility => 1).
       on("vms").
       after(:delete) do
-    "DELETE FROM taggings WHERE resource_type='Vm' AND resource_id=OLD.id;"
+    "DELETE FROM tags WHERE resource_type='Vm' AND resource_id=OLD.id;"
   end
 
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -604,6 +604,8 @@ ActiveRecord::Schema.define(version: 2019_02_15_133418) do
   add_foreign_key "sources", "tenants", on_delete: :cascade
   add_foreign_key "subscriptions", "sources", on_delete: :cascade
   add_foreign_key "subscriptions", "tenants", on_delete: :cascade
+  add_foreign_key "taggings", "tags", on_delete: :cascade
+  add_foreign_key "taggings", "tenants", on_delete: :cascade
   add_foreign_key "tags", "tenants", on_delete: :cascade
   add_foreign_key "tasks", "tenants", on_delete: :cascade
   add_foreign_key "vms", "flavors", on_delete: :nullify

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_14_170341) do
+ActiveRecord::Schema.define(version: 2019_02_15_133418) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -619,4 +619,46 @@ ActiveRecord::Schema.define(version: 2019_02_14_170341) do
   add_foreign_key "volumes", "sources", on_delete: :cascade
   add_foreign_key "volumes", "tenants", on_delete: :cascade
   add_foreign_key "volumes", "volume_types", on_delete: :cascade
+  create_trigger("container_groups_after_delete_row_tr", :generated => true, :compatibility => 1).
+      on("container_groups").
+      after(:delete) do
+    "DELETE FROM taggings WHERE resource_type='ContainerGroup' AND resource_id=OLD.id;"
+  end
+
+  create_trigger("container_projects_after_delete_row_tr", :generated => true, :compatibility => 1).
+      on("container_projects").
+      after(:delete) do
+    "DELETE FROM taggings WHERE resource_type='ContainerProject' AND resource_id=OLD.id;"
+  end
+
+  create_trigger("container_nodes_after_delete_row_tr", :generated => true, :compatibility => 1).
+      on("container_nodes").
+      after(:delete) do
+    "DELETE FROM taggings WHERE resource_type='ContainerNode' AND resource_id=OLD.id;"
+  end
+
+  create_trigger("container_images_after_delete_row_tr", :generated => true, :compatibility => 1).
+      on("container_images").
+      after(:delete) do
+    "DELETE FROM taggings WHERE resource_type='ContainerImage' AND resource_id=OLD.id;"
+  end
+
+  create_trigger("container_templates_after_delete_row_tr", :generated => true, :compatibility => 1).
+      on("container_templates").
+      after(:delete) do
+    "DELETE FROM taggings WHERE resource_type='ContainerTemplate' AND resource_id=OLD.id;"
+  end
+
+  create_trigger("service_offerings_after_delete_row_tr", :generated => true, :compatibility => 1).
+      on("service_offerings").
+      after(:delete) do
+    "DELETE FROM taggings WHERE resource_type='ServiceOffering' AND resource_id=OLD.id;"
+  end
+
+  create_trigger("vms_after_delete_row_tr", :generated => true, :compatibility => 1).
+      on("vms").
+      after(:delete) do
+    "DELETE FROM taggings WHERE resource_type='Vm' AND resource_id=OLD.id;"
+  end
+
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_02_13_155142) do
+ActiveRecord::Schema.define(version: 2019_02_14_170341) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -27,17 +27,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.bigint "tenant_id", null: false
     t.index ["resource_type", "resource_id"], name: "index_authentications_on_resource_type_and_resource_id"
     t.index ["tenant_id"], name: "index_authentications_on_tenant_id"
-  end
-
-  create_table "container_group_tags", id: :serial, force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "container_group_id", null: false
-    t.index ["container_group_id", "tag_id", "value"], name: "uniq_index_on_container_group_id_tag_id_and_value", unique: true
-    t.index ["tag_id"], name: "index_container_group_tags_on_tag_id"
-    t.index ["tenant_id"], name: "index_container_group_tags_on_tenant_id"
   end
 
   create_table "container_groups", force: :cascade do |t|
@@ -67,17 +56,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.index ["tenant_id"], name: "index_container_groups_on_tenant_id"
   end
 
-  create_table "container_image_tags", id: :serial, force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "container_image_id", null: false
-    t.index ["container_image_id", "tag_id", "value"], name: "uniq_index_on_container_image_id_tag_id_and_value", unique: true
-    t.index ["tag_id"], name: "index_container_image_tags_on_tag_id"
-    t.index ["tenant_id"], name: "index_container_image_tags_on_tenant_id"
-  end
-
   create_table "container_images", force: :cascade do |t|
     t.bigint "tenant_id", null: false
     t.bigint "source_id", null: false
@@ -98,17 +76,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.index ["last_seen_at"], name: "index_container_images_on_last_seen_at"
     t.index ["source_id", "source_ref"], name: "index_container_images_on_source_id_and_source_ref", unique: true
     t.index ["tenant_id"], name: "index_container_images_on_tenant_id"
-  end
-
-  create_table "container_node_tags", id: :serial, force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "container_node_id", null: false
-    t.index ["container_node_id", "tag_id", "value"], name: "uniq_index_on_container_node_id_tag_id_and_value", unique: true
-    t.index ["tag_id"], name: "index_container_node_tags_on_tag_id"
-    t.index ["tenant_id"], name: "index_container_node_tags_on_tenant_id"
   end
 
   create_table "container_nodes", force: :cascade do |t|
@@ -139,17 +106,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.index ["tenant_id"], name: "index_container_nodes_on_tenant_id"
   end
 
-  create_table "container_project_tags", id: :serial, force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "container_project_id", null: false
-    t.index ["container_project_id", "tag_id", "value"], name: "uniq_index_on_container_project_id_tag_id_and_value", unique: true
-    t.index ["tag_id"], name: "index_container_project_tags_on_tag_id"
-    t.index ["tenant_id"], name: "index_container_project_tags_on_tenant_id"
-  end
-
   create_table "container_projects", force: :cascade do |t|
     t.bigint "source_id", null: false
     t.string "source_ref", null: false
@@ -172,17 +128,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.index ["source_deleted_at"], name: "index_container_projects_on_source_deleted_at"
     t.index ["source_id", "source_ref"], name: "index_container_projects_on_source_id_and_source_ref", unique: true
     t.index ["tenant_id"], name: "index_container_projects_on_tenant_id"
-  end
-
-  create_table "container_template_tags", id: :serial, force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "container_template_id", null: false
-    t.index ["container_template_id", "tag_id", "value"], name: "uniq_index_on_container_template_id_tag_id_and_value", unique: true
-    t.index ["tag_id"], name: "index_container_template_tags_on_tag_id"
-    t.index ["tenant_id"], name: "index_container_template_tags_on_tenant_id"
   end
 
   create_table "container_templates", force: :cascade do |t|
@@ -359,17 +304,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.index ["tenant_id"], name: "index_service_offering_icons_on_tenant_id"
   end
 
-  create_table "service_offering_tags", id: :serial, force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "service_offering_id", null: false
-    t.index ["service_offering_id", "tag_id", "value"], name: "uniq_index_on_service_offering_id_tag_id_and_value", unique: true
-    t.index ["tag_id"], name: "index_service_offering_tags_on_tag_id"
-    t.index ["tenant_id"], name: "index_service_offering_tags_on_tenant_id"
-  end
-
   create_table "service_offerings", force: :cascade do |t|
     t.bigint "source_id", null: false
     t.string "source_ref", null: false
@@ -490,6 +424,19 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.index ["tenant_id"], name: "index_subscriptions_on_tenant_id"
   end
 
+  create_table "taggings", force: :cascade do |t|
+    t.bigint "tenant_id", null: false
+    t.string "resource_type", null: false
+    t.bigint "resource_id", null: false
+    t.bigint "tag_id", null: false
+    t.string "value"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["resource_type", "resource_id"], name: "index_taggings_on_resource_type_and_resource_id"
+    t.index ["tag_id"], name: "index_taggings_on_tag_id"
+    t.index ["tenant_id"], name: "index_taggings_on_tenant_id"
+  end
+
   create_table "tags", id: :serial, force: :cascade do |t|
     t.bigint "tenant_id", null: false
     t.string "name", null: false
@@ -517,17 +464,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
     t.string "external_tenant"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-  end
-
-  create_table "vm_tags", id: :serial, force: :cascade do |t|
-    t.bigint "tenant_id", null: false
-    t.bigint "tag_id", null: false
-    t.string "value", default: "", null: false
-    t.datetime "created_at", null: false
-    t.bigint "vm_id", null: false
-    t.index ["tag_id"], name: "index_vm_tags_on_tag_id"
-    t.index ["tenant_id"], name: "index_vm_tags_on_tenant_id"
-    t.index ["vm_id", "tag_id", "value"], name: "uniq_index_on_vm_id_tag_id_and_value", unique: true
   end
 
   create_table "vms", force: :cascade do |t|
@@ -618,31 +554,16 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
   end
 
   add_foreign_key "authentications", "tenants", on_delete: :cascade
-  add_foreign_key "container_group_tags", "container_groups", on_delete: :cascade
-  add_foreign_key "container_group_tags", "tags", on_delete: :cascade
-  add_foreign_key "container_group_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_groups", "container_nodes", on_delete: :cascade
   add_foreign_key "container_groups", "container_projects", on_delete: :cascade
   add_foreign_key "container_groups", "sources", on_delete: :cascade
   add_foreign_key "container_groups", "tenants", on_delete: :cascade
-  add_foreign_key "container_image_tags", "container_images", on_delete: :cascade
-  add_foreign_key "container_image_tags", "tags", on_delete: :cascade
-  add_foreign_key "container_image_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_images", "sources", on_delete: :cascade
   add_foreign_key "container_images", "tenants", on_delete: :cascade
-  add_foreign_key "container_node_tags", "container_nodes", on_delete: :cascade
-  add_foreign_key "container_node_tags", "tags", on_delete: :cascade
-  add_foreign_key "container_node_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_nodes", "sources", on_delete: :cascade
   add_foreign_key "container_nodes", "tenants", on_delete: :cascade
-  add_foreign_key "container_project_tags", "container_projects", on_delete: :cascade
-  add_foreign_key "container_project_tags", "tags", on_delete: :cascade
-  add_foreign_key "container_project_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_projects", "sources", on_delete: :cascade
   add_foreign_key "container_projects", "tenants", on_delete: :cascade
-  add_foreign_key "container_template_tags", "container_templates", on_delete: :cascade
-  add_foreign_key "container_template_tags", "tags", on_delete: :cascade
-  add_foreign_key "container_template_tags", "tenants", on_delete: :cascade
   add_foreign_key "container_templates", "container_projects", on_delete: :cascade
   add_foreign_key "container_templates", "sources", on_delete: :cascade
   add_foreign_key "container_templates", "tenants", on_delete: :cascade
@@ -667,9 +588,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
   add_foreign_key "service_instances", "tenants", on_delete: :cascade
   add_foreign_key "service_offering_icons", "sources", on_delete: :cascade
   add_foreign_key "service_offering_icons", "tenants", on_delete: :cascade
-  add_foreign_key "service_offering_tags", "service_offerings", on_delete: :cascade
-  add_foreign_key "service_offering_tags", "tags", on_delete: :cascade
-  add_foreign_key "service_offering_tags", "tenants", on_delete: :cascade
   add_foreign_key "service_offerings", "service_offering_icons", on_delete: :nullify
   add_foreign_key "service_offerings", "source_regions", on_delete: :cascade
   add_foreign_key "service_offerings", "sources", on_delete: :cascade
@@ -688,9 +606,6 @@ ActiveRecord::Schema.define(version: 2019_02_13_155142) do
   add_foreign_key "subscriptions", "tenants", on_delete: :cascade
   add_foreign_key "tags", "tenants", on_delete: :cascade
   add_foreign_key "tasks", "tenants", on_delete: :cascade
-  add_foreign_key "vm_tags", "tags", on_delete: :cascade
-  add_foreign_key "vm_tags", "tenants", on_delete: :cascade
-  add_foreign_key "vm_tags", "vms", on_delete: :cascade
   add_foreign_key "vms", "flavors", on_delete: :nullify
   add_foreign_key "vms", "orchestration_stacks", on_delete: :nullify
   add_foreign_key "vms", "sources", on_delete: :cascade

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -17,6 +17,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
   s.add_runtime_dependency "acts_as_tenant"
+  s.add_runtime_dependency "hairtrigger"
   s.add_runtime_dependency "manageiq-messaging", "~> 0.1.0"
   s.add_runtime_dependency "manageiq-password",  "~> 0.2"
   s.add_runtime_dependency "pg", "> 0"


### PR DESCRIPTION
Move to a single polymorphic `Tagging` join table and use DB after delete triggers to cleanup associated taggings when a tagged item is deleted.

Uses the hair_trigger gem https://github.com/jenseng/hair_trigger to define the trigger in the mixin that way models can just `include acts_as_taggable_on` and run `rake db:generate_trigger_migration` to get triggers.

This makes no attempt to migrate data out of the join tables or implement a down migration, just for proof of concept.