### PR TITLE
Add source type schemas for OpenShift and Amazon.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -7,5 +7,22 @@ def update_or_create(model, attributes)
   end
 end
 
-update_or_create(SourceType, :name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat")
-update_or_create(SourceType, :name => "amazon", :product_name => "AWS", :vendor => "Amazon")
+openshift_json_schema = {
+  :title  => "Configure OpenShift",
+  :fields => [
+    {:component => "text-field", :name => "url", :label => "URL"},
+    {:component => "checkbox", :name => "verify_ssl", :label => "Verify SSL"},
+    {:component => "text-field", :name => "certificate_authority", :label => "Certificate Authority", :condition => {:when => "verify_ssl", :is => true}},
+    {:component => "textarea-field", :name => "token", :label => "Token"}
+  ]
+}
+update_or_create(SourceType, :name => "openshift", :product_name => "OpenShift", :vendor => "Red Hat", :schema => openshift_json_schema)
+
+amazon_json_schema = {
+  :title  => "Configure AWS",
+  :fields => [
+    {:component => "text-field", :name => "user_name", :label => "Access Key"},
+    {:component => "text-field", :name => "password", :label => "Secret Key"}
+  ]
+}
+update_or_create(SourceType, :name => "amazon", :product_name => "AWS", :vendor => "Amazon", :schema => amazon_json_schema)


### PR DESCRIPTION
Add source type schemas for OpenShift and Amazon. These are in turn used to render the "Add a New Source" form in https://github.com/ManageIQ/topological_inventory-ui.

To be used together with https://github.com/ManageIQ/topological_inventory-ui/pull/17 and https://github.com/ManageIQ/topological_inventory-ui/pull/20

Seeding the JSON columns with a ruby hash, comes out of the API as a JSON object. :+1: 

### ~~TODO~~

~~Seeding the JSON column as a string, comes out of the API as a string.~~
