### PR TITLE
Remove tenant reference from tag models

### DIFF
--- a/app/models/container_group_tag.rb
+++ b/app/models/container_group_tag.rb
@@ -1,8 +1,4 @@
 class ContainerGroupTag < ApplicationRecord
-  belongs_to :tenant
-
   belongs_to :container_group
   belongs_to :tag
-
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_image_tag.rb
+++ b/app/models/container_image_tag.rb
@@ -1,8 +1,4 @@
 class ContainerImageTag < ApplicationRecord
-  belongs_to :tenant
-
   belongs_to :container_image
   belongs_to :tag
-
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_node_tag.rb
+++ b/app/models/container_node_tag.rb
@@ -1,8 +1,4 @@
 class ContainerNodeTag < ApplicationRecord
-  belongs_to :tenant
-
   belongs_to :container_node
   belongs_to :tag
-
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_project_tag.rb
+++ b/app/models/container_project_tag.rb
@@ -1,8 +1,4 @@
 class ContainerProjectTag < ApplicationRecord
-  belongs_to :tenant
-
   belongs_to :container_project
   belongs_to :tag
-
-  acts_as_tenant(:tenant)
 end

--- a/app/models/container_template_tag.rb
+++ b/app/models/container_template_tag.rb
@@ -1,8 +1,4 @@
 class ContainerTemplateTag < ApplicationRecord
-  belongs_to :tenant
-
   belongs_to :container_template
   belongs_to :tag
-
-  acts_as_tenant(:tenant)
 end

--- a/app/models/service_offering_tag.rb
+++ b/app/models/service_offering_tag.rb
@@ -1,8 +1,4 @@
 class ServiceOfferingTag < ApplicationRecord
-  belongs_to :tenant
-
   belongs_to :service_offering
   belongs_to :tag
-
-  acts_as_tenant(:tenant)
 end

--- a/app/models/vm_tag.rb
+++ b/app/models/vm_tag.rb
@@ -1,8 +1,4 @@
 class VmTag < ApplicationRecord
-  belongs_to :tenant
-
   belongs_to :vm
   belongs_to :tag
-
-  acts_as_tenant(:tenant)
 end


### PR DESCRIPTION
Those references require `tenant_id` columns in tag models (e.g. `ContainerImageTag,...`) and those columns have  been removed in https://github.com/ManageIQ/topological_inventory-core/pull/109/commits/f2fd6e18569196b02a48f97bf2fea027dda50897.


cc @Ladas @agrare 
