### PR TITLE
Fix issues with api clients looking for Rails.logger

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -6,6 +6,10 @@ class ApplicationRecord < ActiveRecord::Base
       module VERSION
         MAJOR = ActiveRecord::VERSION::MAJOR
       end
+      def self.logger
+        require "topological_inventory/core/logger"
+        TopologicalInventory::Core.logger
+      end
     end
   end if !defined?(::Rails) || !::Rails.const_defined?("VERSION")
   require 'acts_as_tenant'

--- a/lib/topological_inventory/core/logging.rb
+++ b/lib/topological_inventory/core/logging.rb
@@ -1,0 +1,19 @@
+require "manageiq/loggers"
+
+module TopologicalInventory
+  module Core
+    class << self
+      attr_writer :logger
+    end
+
+    def self.logger
+      @logger ||= ManageIQ::Loggers::Container.new
+    end
+
+    module Logging
+      def logger
+        TopologicalInventory::Core.logger
+      end
+    end
+  end
+end


### PR DESCRIPTION
The API clients initial configuration looks to see if Rails constant is defined and if it is will use Rails.logger.  Since we hack Rails::VERSION but do not set Rails.logger this causes any OpenAPI clients to throw an exception on initial configuration:

```
Traceback (most recent call last):
	4: from bin/sources-sync:33:in `<main>'
	3: from /home/agrare/.gem/bundler/gems/sources-api-client-ruby-632713f8cc89/lib/sources-api-client.rb:48:in `configure'
	2: from /home/agrare/.gem/bundler/gems/sources-api-client-ruby-632713f8cc89/lib/sources-api-client/configuration.rb:153:in `default'
	1: from /home/agrare/.gem/bundler/gems/sources-api-client-ruby-632713f8cc89/lib/sources-api-client/configuration.rb:153:in `new'
/home/agrare/.gem/bundler/gems/sources-api-client-ruby-632713f8cc89/lib/sources-api-client/configuration.rb:146:in `initialize': undefined method `logger' for Rails:Module (NoMethodError)
```