### PR TITLE
Add "role" to source_type seeds.

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -10,6 +10,7 @@ end
 openshift_json_schema = {
   :title  => "Configure OpenShift",
   :fields => [
+    {:component => "text-field", :name => "role", :type => "hidden", :initialValue => "kubernetes"},
     {:component => "text-field", :name => "url", :label => "URL"},
     {:component => "checkbox", :name => "verify_ssl", :label => "Verify SSL"},
     {:component => "text-field", :name => "certificate_authority", :label => "Certificate Authority", :condition => {:when => "verify_ssl", :is => true}},
@@ -21,6 +22,7 @@ update_or_create(SourceType, :name => "openshift", :product_name => "OpenShift",
 amazon_json_schema = {
   :title  => "Configure AWS",
   :fields => [
+    {:component => "text-field", :name => "role", :type => "hidden", :initialValue => "aws"},
     {:component => "text-field", :name => "user_name", :label => "Access Key"},
     {:component => "text-field", :name => "password", :label => "Secret Key", :type => "password"}
   ]
@@ -30,6 +32,7 @@ update_or_create(SourceType, :name => "amazon", :product_name => "AWS", :vendor 
 ansible_tower_json_schema = {
   :title  => "Configure AnsibleTower",
   :fields => [
+    {:component => "text-field", :name => "role", :type => "hidden", :initialValue => "ansible"}, # FIXME: Find the correct value.
     {:component => "text-field", :name => "url", :label => "URL"},
     {:component => "checkbox", :name => "verify_ssl", :label => "Verify SSL"},
     {:component => "text-field", :name => "certificate_authority", :label => "Certificate Authority", :condition => {:when => "verify_ssl", :is => true}},


### PR DESCRIPTION
The `role` value is needed when creating `Endpoint` instances. Until recently this has beed hard-wired in the client.