### PR TITLE
Tenant needs to inherit from ApplicationRecord

### DIFF
--- a/app/models/tenant.rb
+++ b/app/models/tenant.rb
@@ -1,4 +1,4 @@
-class Tenant < ActiveRecord::Base
+class Tenant < ApplicationRecord
   has_many :authentications
   has_many :containers
   has_many :container_groups


### PR DESCRIPTION
This was breaking the as_json handling in -api because it prepended
OpenApi::Serializer to ApplicationRecord.