### PR TITLE
Source's settings for storing collector settings

### DIFF
--- a/db/migrate/20190416123117_add_config_to_endpoint.rb
+++ b/db/migrate/20190416123117_add_config_to_endpoint.rb
@@ -1,5 +1,0 @@
-class AddConfigToEndpoint < ActiveRecord::Migration[5.2]
-  def change
-    add_column :endpoints, :config, :string
-  end
-end

--- a/db/migrate/20190416123117_add_config_to_endpoint.rb
+++ b/db/migrate/20190416123117_add_config_to_endpoint.rb
@@ -1,0 +1,5 @@
+class AddConfigToEndpoint < ActiveRecord::Migration[5.2]
+  def change
+    add_column :endpoints, :config, :string
+  end
+end

--- a/db/migrate/20190416123117_add_settings_to_source.rb
+++ b/db/migrate/20190416123117_add_settings_to_source.rb
@@ -1,0 +1,5 @@
+class AddSettingsToSource < ActiveRecord::Migration[5.2]
+  def change
+    add_column :sources, :settings, :jsonb
+  end
+end


### PR DESCRIPTION
MockSource's settings can be customized through YAML in string.
- [ ] https://github.com/ManageIQ/topological_inventory-mock_source/pull/17/

These custom source's settings have to be stored somewhere for orchestrator.