### PR TITLE
Add missing acts_as_tenant_on to volume models

### DIFF
--- a/app/models/volume.rb
+++ b/app/models/volume.rb
@@ -10,4 +10,6 @@ class Volume < ApplicationRecord
 
   has_many :volume_attachments
   has_many :vms, :through => :volume_attachments
+
+  acts_as_tenant(:tenant)
 end

--- a/app/models/volume_attachment.rb
+++ b/app/models/volume_attachment.rb
@@ -2,4 +2,6 @@ class VolumeAttachment < ApplicationRecord
   belongs_to :tenant
   belongs_to :volume
   belongs_to :vm
+
+  acts_as_tenant(:tenant)
 end

--- a/app/models/volume_type.rb
+++ b/app/models/volume_type.rb
@@ -7,4 +7,6 @@ class VolumeType < ApplicationRecord
   belongs_to :source
 
   has_many :volumes
+
+  acts_as_tenant(:tenant)
 end


### PR DESCRIPTION
Some models had a tenant_id but did not include the acts_as_tenant mixin so they were not being filtered by the API