### PR TITLE
Prevent re-requiring models leading to warnings in test

### DIFF
--- a/lib/topological_inventory/core/ar_helper.rb
+++ b/lib/topological_inventory/core/ar_helper.rb
@@ -40,7 +40,7 @@ module TopologicalInventory
         $LOAD_PATH << root.join("app", "models", "concerns")
 
         ActiveSupport::Dependencies.autoload_paths << root.join("app", "models")
-        ActiveSupport::Dependencies.autoload_paths << root.join("app", "models", "concenrs")
+        ActiveSupport::Dependencies.autoload_paths << root.join("app", "models", "concerns")
       end
     end
   end

--- a/lib/topological_inventory/core/ar_helper.rb
+++ b/lib/topological_inventory/core/ar_helper.rb
@@ -32,7 +32,10 @@ module TopologicalInventory
       end
 
       def self.root
-        @root ||= Pathname.new(__dir__).join("../../..").expand_path
+        @root ||= begin
+          require 'pathname'
+          Pathname.new(__dir__).join("../../..").expand_path
+        end
       end
 
       private_class_method def self.autoload_models

--- a/lib/topological_inventory/core/ar_helper.rb
+++ b/lib/topological_inventory/core/ar_helper.rb
@@ -21,7 +21,7 @@ module TopologicalInventory
         ActiveRecord::Tasks::DatabaseTasks.db_dir = root.join("db")
         ActiveRecord::Tasks::DatabaseTasks.migrations_paths = [root.join("db/migrate")]
 
-        load_models
+        autoload_models
 
         require "topological_inventory/core/seed_loader"
         ActiveRecord::Tasks::DatabaseTasks.seed_loader = TopologicalInventory::Core::SeedLoader
@@ -35,15 +35,12 @@ module TopologicalInventory
         @root ||= Pathname.new(__dir__).join("../../..").expand_path
       end
 
-      private_class_method def self.load_models
+      private_class_method def self.autoload_models
         $LOAD_PATH << root.join("app", "models")
         $LOAD_PATH << root.join("app", "models", "concerns")
 
         ActiveSupport::Dependencies.autoload_paths << root.join("app", "models")
         ActiveSupport::Dependencies.autoload_paths << root.join("app", "models", "concenrs")
-
-        require "application_record"
-        Dir[root.join("app/models/**/*.rb")].each { |f| require f }
       end
     end
   end


### PR DESCRIPTION
Previously...
```
$ rake
app/models/source.rb:67: warning: already initialized constant Source::ALLOWED_REFRESH_STATUS_VALUES
app/models/source.rb:67: warning: previous definition of ALLOWED_REFRESH_STATUS_VALUES was here
```