### PR TITLE
Remove the Rails hack needed for acts_as_tenant

### DIFF
--- a/app/models/application_record.rb
+++ b/app/models/application_record.rb
@@ -1,17 +1,4 @@
 class ApplicationRecord < ActiveRecord::Base
-  # Hack for running acts_as_tenant in a non Rails env.
-  # See https://github.com/ErwinM/acts_as_tenant/pull/192 for proposed fix
-  begin
-    module ::Rails
-      module VERSION
-        MAJOR = ActiveRecord::VERSION::MAJOR
-      end
-      def self.logger
-        require "topological_inventory/core/logging"
-        TopologicalInventory::Core.logger
-      end
-    end
-  end if !defined?(::Rails) || !::Rails.const_defined?("VERSION")
   require 'acts_as_tenant'
 
   self.abstract_class = true

--- a/topological_inventory-core.gemspec
+++ b/topological_inventory-core.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
 
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE.txt", "Rakefile", "README.md"]
 
-  s.add_runtime_dependency "acts_as_tenant"
+  s.add_runtime_dependency "acts_as_tenant",    "~> 0.4.4"
   s.add_runtime_dependency "inventory_refresh", "~> 0.3.0"
   s.add_runtime_dependency "manageiq-messaging", "~> 0.1.0"
   s.add_runtime_dependency "manageiq-password",  "~> 0.3"


### PR DESCRIPTION
Now that acts_as_tenant has released the gem with our fix we don't need
this hack anymore.