### PR TITLE
Fix the Source.datastore_mounts through relation

### DIFF
--- a/app/models/source.rb
+++ b/app/models/source.rb
@@ -34,13 +34,13 @@ class Source < ApplicationRecord
   has_many :subscriptions
 
   # Infra/Cloud
+  has_many :hosts
   has_many :clusters
   has_many :cluster_tags, :through => :clusters
   has_many :datastores
   has_many :datastore_tags, :through => :datastores
   has_many :datastore_mounts, :through => :hosts
   has_many :flavors
-  has_many :hosts
   has_many :host_tags, :through => :hosts
   has_many :orchestration_stacks
   has_many :reservations


### PR DESCRIPTION
The datastore_mounts relation was defined through :hosts before the
hosts relation was defined.