### PR TITLE
Fix optional belongs_to

### DIFF
--- a/app/models/service_instance.rb
+++ b/app/models/service_instance.rb
@@ -9,8 +9,8 @@ class ServiceInstance < ApplicationRecord
   belongs_to :service_plan
   belongs_to :source_region
   belongs_to :subscription
-  belongs_to :service_inventory
-  belongs_to :root_service_instance, :class_name => "ServiceInstance"
+  belongs_to :service_inventory,     :optional => true
+  belongs_to :root_service_instance, :optional => true, :class_name => "ServiceInstance"
 
   has_many :service_instance_nodes
   has_many :child_service_instance_nodes, :class_name => "ServiceInstanceNode", :foreign_key => :root_service_instance

--- a/app/models/service_instance_node.rb
+++ b/app/models/service_instance_node.rb
@@ -5,9 +5,9 @@ class ServiceInstanceNode < ApplicationRecord
 
   belongs_to :tenant
   belongs_to :source
-  belongs_to :service_instance
-  belongs_to :root_service_instance, :class_name => "ServiceInstance"
-  belongs_to :service_inventory
+  belongs_to :service_instance,      :optional => true
+  belongs_to :root_service_instance, :optional => true, :class_name => "ServiceInstance"
+  belongs_to :service_inventory,     :optional => true
 
   acts_as_tenant(:tenant)
 end

--- a/app/models/service_offering.rb
+++ b/app/models/service_offering.rb
@@ -8,7 +8,7 @@ class ServiceOffering < ApplicationRecord
   belongs_to :source
   belongs_to :source_region
   belongs_to :subscription
-  belongs_to :service_inventory
+  belongs_to :service_inventory, :optional => true
 
   has_many   :service_instances
   has_many   :service_plans

--- a/app/models/service_offering_node.rb
+++ b/app/models/service_offering_node.rb
@@ -5,9 +5,9 @@ class ServiceOfferingNode < ApplicationRecord
 
   belongs_to :tenant
   belongs_to :source
-  belongs_to :service_offering
-  belongs_to :root_service_offering, :class_name => "ServiceOffering"
-  belongs_to :service_inventory
+  belongs_to :service_offering,      :optional => true
+  belongs_to :root_service_offering, :optional => true, :class_name => "ServiceOffering"
+  belongs_to :service_inventory,     :optional => true
 
   acts_as_tenant(:tenant)
 end


### PR DESCRIPTION
Most belongs_to relations are optional in the database but default to
required with the newer version of rails.